### PR TITLE
Changes required for the SCARF cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 runs/*
 __pycache__/*
+**.*egg-info

--- a/ImageQualityCallback.py
+++ b/ImageQualityCallback.py
@@ -86,7 +86,7 @@ class ImageQualityCallback:
 
         # get the voxel sizes from the input reference image
         # since STIR and CIL use different way to store the voxel sizes
-        # we test for the attributes voxel_siszes (STIR) and geometry.voxel_size_x (CIL
+        # we test for the attributes voxel_sizes (STIR) and geometry.voxel_size_x (CIL
         if hasattr(reference_image, 'voxel_sizes'):
             # STIR image
             self.voxel_size_mm = reference_image.voxel_sizes()

--- a/ImageQualityCallback.py
+++ b/ImageQualityCallback.py
@@ -143,7 +143,6 @@ class ImageQualityCallback:
                 reference_image_array_ps = reference_image_array
 
             # (1) calculate global metrics and statistics
-            global_metrics    = {}
             if self.metrics_dict is not None:
                 for metric_name, metric in self.metrics_dict.items():
                     met = metric(test_image_array_ps.ravel(), reference_image_array_ps.ravel())
@@ -151,12 +150,10 @@ class ImageQualityCallback:
                     # for the 2nd case, we save each scalar value separately in the dict
                     if isinstance(met, np.ndarray):
                         for im, m in enumerate(met.ravel()):
-                            global_metrics[f'{metric_name}_{im}'] = m
+                            self.tb_summary_writer.add_scalar(f'Global_{metric_name}_{im}{ps_str}',  m, iteration)
                     else:
-                        global_metrics[metric_name] = met
-                self.tb_summary_writer.add_scalars(f'global_metrics{ps_str}', global_metrics, iteration)
+                        self.tb_summary_writer.add_scalar(f'Global_{metric_name}{ps_str}',  met, iteration)
 
-            global_statistics = {}
             if self.statistics_dict is not None:
                 for statistic_name, statistic in self.statistics_dict.items():
                     stat = statistic(test_image_array_ps.ravel())
@@ -164,16 +161,13 @@ class ImageQualityCallback:
                     # for the 2nd case, we save each scalar value separately in the dict
                     if isinstance(stat, np.ndarray):
                         for ist, st in enumerate(stat.ravel()):
-                            global_statistics[f'{statistic_name}_{ist}'] = st
+                            self.tb_summary_writer.add_scalar(f'Local_{statistic_name}_{ist}{ps_str}',  st, iteration)
                     else:
-                        global_statistics[statistic_name] = stat
-                self.tb_summary_writer.add_scalars(f'global_statistics{ps_str}', global_statistics, iteration)
+                        self.tb_summary_writer.add_scalar(f'Global_{statistic_name}{ps_str}',  stat, iteration)
   
             # (2) caluclate local metrics and statistics
             if self.roi_indices_dict is not None:
                 for roi_name, roi_inds in self.roi_indices_dict.items():
-                    roi_metrics    = {}
-                    roi_statistics = {}
 
                     if self.metrics_dict is not None:
                         for metric_name, metric in self.metrics_dict.items():
@@ -182,10 +176,9 @@ class ImageQualityCallback:
                             # for the 2nd case, we save each scalar value separately in the dict
                             if isinstance(met, np.ndarray):
                                 for im, m in enumerate(roi_met.ravel()):
-                                    roi_metrics[f'{metric_name}_{im}'] = m
+                                    self.tb_summary_writer.add_scalar(f'Local_{roi_name}_{metric_name}_{im}{ps_str}',  m, iteration)
                             else:
-                                roi_metrics[metric_name] = roi_met
-                        self.tb_summary_writer.add_scalars(f'{roi_name}_metrics{ps_str}', roi_metrics, iteration)
+                                self.tb_summary_writer.add_scalar(f'Local_{roi_name}_{metric_name}{ps_str}',  roi_met, iteration)
 
                     if self.statistics_dict is not None:
                         for statistic_name, statistic in self.statistics_dict.items():
@@ -194,7 +187,6 @@ class ImageQualityCallback:
                             # for the 2nd case, we save each scalar value separately in the dict
                             if isinstance(roi_stat, np.ndarray):
                                 for ist, st in enumerate(roi_stat.ravel()):
-                                    roi_statistics[f'{statistic_name}_{ist}'] = st
+                                    self.tb_summary_writer.add_scalar(f'Local_{roi_name}_{statistic_name}_{im}{ps_str}',  st, iteration)
                             else:
-                                roi_statistics[statistic_name] = roi_stat
-                        self.tb_summary_writer.add_scalars(f'{roi_name}_statistics{ps_str}', roi_statistics, iteration)
+                                self.tb_summary_writer.add_scalar(f'Local_{roi_name}_{statistic_name}{ps_str}',  roi_stat, iteration)

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .ImageQualityCallback import *

--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,7 @@ setup(
     name='StochasticHackathonQualityMetrics',
     version='0.1.0',
     packages=[''],
+    install_requires=['numpy',
+                      'scipy',
+                      'tensorboardX'],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='StochasticHackathonQualityMetrics',
+    version='0.1.0',
+    packages=[''],
+)


### PR DESCRIPTION
By using add_scalars rather than add_scalar a set of tensorboard files were created in their respective cascading folder structure. Instead it is makes more sense to have a single tensorboard "experiment" with multiple scalars. Additionally a setup.py and __init__.py are used to add install the packages into the site packages of the conda/pip environment. 